### PR TITLE
Fix a namespace declaration

### DIFF
--- a/include/ICWFGM_FBPFuel.h
+++ b/include/ICWFGM_FBPFuel.h
@@ -22,7 +22,7 @@
 
 
 // done this way to avoid some files that can't be compiled as Cxx17
-namespace CWFGM {
+namespace WISE {
 	namespace FuelProto {
 		enum FuelName : int;
 	}


### PR DESCRIPTION
The protobuf namespace was being forward declared but it hadn't been updated for the move to WISE.