### PR TITLE
deserialize implementation vs. declaration

### DIFF
--- a/cpp/ICWFGM_CommonBase.cpp
+++ b/cpp/ICWFGM_CommonBase.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "ICWFGM_CommonBase.h"
+#include "ISerializeProto.h"
 
 #include "WTime.h"
 
@@ -306,4 +307,17 @@ HRESULT ICWFGM_CommonBase::get_UserData(PolymorphicUserData *pVal) const {
 HRESULT ICWFGM_CommonBase::put_UserData(const PolymorphicUserData &newVal) {
 	m_userData = newVal;
 	return S_OK;
+}
+
+
+ISerializeProto::DeserializeError::DeserializeError(const std::string& message) :
+	logic_error(message)
+{
+}
+
+
+ISerializeProto::DeserializeError::DeserializeError(const std::string& message, std::uint32_t hr_) :
+	logic_error(message)
+{
+	hr = hr_;
 }

--- a/include/ISerializeProto.h
+++ b/include/ISerializeProto.h
@@ -75,19 +75,13 @@ public:
 class ISerializeProto {
 public:
 
-	class DeserializeError : public std::logic_error {
+	class FUELCOM_API DeserializeError : public std::logic_error {
 	protected:
 		std::string msg_;
 
 	public:
-		explicit DeserializeError(const std::string& message) :
-			logic_error(message)
-		{}
-		explicit DeserializeError(const std::string& message, std::uint32_t hr_) :
-			logic_error(message)
-		{
-			hr = hr_;
-		}
+		explicit DeserializeError(const std::string& message);
+		explicit DeserializeError(const std::string& message, std::uint32_t hr_);
 
 		std::uint32_t hr = 0;
 	};


### PR DESCRIPTION
Pulling some of the implementation into the source file so that it can't be inlined into more than one binary target, to help with type resolution in catch blocks.

Likely shouldn't be needed but it helped resolve an issue with the latest release of MSVC.